### PR TITLE
feat(education): add migration, model, and controller for education m…

### DIFF
--- a/app/Http/Controllers/api/admin/EducationController.php
+++ b/app/Http/Controllers/api/admin/EducationController.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Http\Controllers\api\admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Education;
+use Illuminate\Http\Request;
+
+class EducationController extends Controller
+{
+    public function storeEducation(Request $request)
+    {
+        $user = $request->user();
+
+        if (!$user) {
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+
+        $validatedData = $request->validate([
+            'level' => 'required',
+            'program' => 'required',
+            'institution' => 'required',
+            'board' => 'required',
+            'start_year' => 'required|date_format:Y',
+            'end_year' => 'nullable|date_format:Y',
+            'description' => 'nullable',
+        ]);
+
+        $education = Education::create($validatedData);
+
+        return response()->json($education, 201);
+    }
+
+    public function viewAllEducations(Request $request)
+    {
+        $user = $request->user();
+
+        if (!$user) {
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+
+        $educations = Education::all();
+        return response()->json($educations);
+    }
+
+    public function updateEducation(Request $request, $id)
+    {
+        $user = $request->user();
+
+        if (!$user) {
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+
+        $education = Education::find($id);
+        if (!$education) {
+            return response()->json(['error' => 'Education not found'], 404);
+        }
+
+        $validatedData = $request->validate([
+            'level' => 'required',
+            'program' => 'required',
+            'institution' => 'required',
+            'board' => 'required',
+            'start_year' => 'required|date_format:Y',
+            'end_year' => 'nullable|date_format:Y',
+            'description' => 'nullable',
+        ]);
+
+        $education->update($validatedData);
+
+        return response()->json([
+            'message' => 'Education updated successfully',
+            'data' => $education
+        ], 200);
+    }
+
+    public function deleteEducation(Request $request, $id)
+    {
+        $user = $request->user();
+
+        if (!$user) {
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+
+        $education = Education::find($id);
+        if (!$education) {
+            return response()->json(['error' => 'Education not found'], 404);
+        }
+
+        $education->delete();
+
+        return response()->json([
+            'message' => 'Education deleted successfully',
+        ], 200);
+    }
+
+    public function viewEducation(Request $request, $id)
+    {
+        $user = $request->user();
+
+        if (!$user) {
+            return response()->json(['error' => 'Unauthorized'], 401);
+        }
+
+        $education = Education::find($id);
+        if (!$education) {
+            return response()->json(['error' => 'Education not found'], 404);
+        }
+
+        return response()->json($education);
+    }
+}

--- a/app/Models/Education.php
+++ b/app/Models/Education.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Education extends Model
+{
+    use HasFactory;
+
+    protected $table = 'educations';
+
+    protected $fillable = [
+        'level',
+        'program',
+        'institution',
+        'board',
+        'start_year',
+        'end_year',
+        'description',
+    ];
+}

--- a/database/migrations/2025_06_12_153107_create_educations_table.php
+++ b/database/migrations/2025_06_12_153107_create_educations_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateEducationsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('educations', function (Blueprint $table) {
+            $table->id();
+            $table->string('level');
+            $table->string('program');
+            $table->string('institution');
+            $table->string('board');
+            $table->year('start_year');
+            $table->year('end_year')->nullable();
+            $table->text('description')->nullable();
+            $table->timestamps(); 
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('educations');
+    }
+}
+

--- a/routes/adminapi.php
+++ b/routes/adminapi.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\api\admin\AdminAuthController;
+use App\Http\Controllers\api\admin\EducationController;
 use App\Http\Controllers\api\admin\ProjectController;
 use App\Http\Controllers\api\admin\ProjectImageController;
 use App\Http\Controllers\api\admin\SkillController;
@@ -26,4 +27,9 @@ Route::prefix('admin')->middleware('auth:admin')->group(function () {
     Route::get('viewskills', [SkillController::class, 'viewAllSkills'])->name('admin.viewskills');
     Route::put('updateskill/{id}', [SkillController::class, 'updateSkill'])->name('admin.updateskill');
     Route::delete('deleteskill/{id}', [SkillController::class, 'deleteSkill'])->name('admin.deleteskill');
+    Route::post('addeducation', [EducationController::class, 'storeEducation'])->name('admin.addeducation');
+    Route::get('vieweducations', [EducationController::class, 'viewAllEducations'])->name('admin.vieweducations');
+    Route::put('updateeducation/{id}', [EducationController::class, 'updateEducation'])->name('admin.updateeducation');
+    Route::delete('deleteeducation/{id}', [EducationController::class, 'deleteEducation'])->name('admin.deleteeducation');
+    Route::get('vieweducation/{id}', [EducationController::class, 'viewEducation'])->name('admin.vieweducation');
 });


### PR DESCRIPTION
Adds migration for educations table to store academic records such as level, program, institution, board, years, and description.
Creates Education model with mass-assignable attributes.
Implements a resourceful controller to handle CRUD operations for education entries.
Includes input validation rules for data integrity.
Supports optional description and nullable end year for ongoing studies.
Registers RESTful API routes for education management.
Prepares the backend foundation for integrating education data into user profiles or other modules.